### PR TITLE
Support bool type value for the Option element in the Generator

### DIFF
--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -21,7 +21,13 @@ class Generator:
                     modifier = "public "
                 lines.append(f'import {modifier}"{element.name}";')
             elif isinstance(element, ast.Option):
-                lines.append(f'option {element.name} = "{element.value}";')
+                if isinstance(element.value, bool):
+                    if element.value:
+                        lines.append(f'option {element.name} = true;')
+                    else:
+                        lines.append(f'option {element.name} = false;')
+                else:
+                    lines.append(f'option {element.name} = "{element.value}";')
             elif isinstance(element, ast.Message):
                 lines.append(self._generate_message(element))
             elif isinstance(element, ast.Enum):

--- a/proto_schema_parser/generator.py
+++ b/proto_schema_parser/generator.py
@@ -23,9 +23,9 @@ class Generator:
             elif isinstance(element, ast.Option):
                 if isinstance(element.value, bool):
                     if element.value:
-                        lines.append(f'option {element.name} = true;')
+                        lines.append(f"option {element.name} = true;")
                     else:
-                        lines.append(f'option {element.name} = false;')
+                        lines.append(f"option {element.name} = false;")
                 else:
                     lines.append(f'option {element.name} = "{element.value}";')
             elif isinstance(element, ast.Message):


### PR DESCRIPTION
Not all option values are `string` type. Some can be `bool` type. For example: `java_multiple_files`.
We should be able to generate `option java_multiple_files = false;` instead of `option java_multiple_files = "false";`